### PR TITLE
Change the default Granite model to 3b

### DIFF
--- a/notebooks/RAG_with_Langchain.ipynb
+++ b/notebooks/RAG_with_Langchain.ipynb
@@ -160,8 +160,7 @@
    "outputs": [],
    "source": [
     "!ollama pull granite-code:3b\n",
-    "!ollama pull granite-code:8b\n",
-    "!ollama pull granite-code:20b"
+    "!ollama pull granite-code:8b"
    ]
   },
   {
@@ -282,7 +281,7 @@
    "source": [
     "from langchain_ollama.llms import OllamaLLM\n",
     "\n",
-    "model = OllamaLLM(model=\"granite-code:8b\")"
+    "model = OllamaLLM(model=\"granite-code:3b\")"
    ]
   },
   {

--- a/notebooks/Text_to_Shell.ipynb
+++ b/notebooks/Text_to_Shell.ipynb
@@ -158,7 +158,7 @@
    "source": [
     "from langchain_ollama.llms import OllamaLLM\n",
     "\n",
-    "model = OllamaLLM(model=\"granite-code:8b\")"
+    "model = OllamaLLM(model=\"granite-code:3b\")"
    ]
   },
   {


### PR DESCRIPTION
8b version of the Granite code model is not very performant when run in Colab. This PR changes the default to 3b which returns more quickly than its 8b paramter counterpart.

The model can be changed by users of the notebook when required.