### PR TITLE
Updates after the first workshop delivery

### DIFF
--- a/docs/pre-work/README.md
+++ b/docs/pre-work/README.md
@@ -156,10 +156,7 @@ Running the lab notebooks remotely using [Google Colab](https://colab.research.g
 
 ### Serving the Granite AI Models for Colab
 
-[Lab 1: Document Summarization with Granite](../lab-1/README.md), [Lab 2: Retrieval Augmented Generation (RAG) with Langchain](../lab-2/README.md) and [Lab 4: Generating Bash Code with Granite Code](../lab-4/README.md) require Granite models to be served by an AI model runtime so that the models can be invoked or called. There are 2 options to serve the models when using Colab as follows:
-
-- [Replicate AI Cloud Platform for Colab](#replicate-ai-cloud-platform-for-colab) OR
-- [Ollama running in Colab](#ollama-running-in-colab)
+[Lab 1: Document Summarization with Granite](../lab-1/README.md), [Lab 2: Retrieval Augmented Generation (RAG) with Langchain](../lab-2/README.md) and [Lab 4: Generating Bash Code with Granite Code](../lab-4/README.md) require Granite models to be served by an AI model runtime so that the models can be invoked or called.
 
 #### Replicate AI Cloud Platform for Colab
 
@@ -172,16 +169,3 @@ Running the lab notebooks remotely using [Google Colab](https://colab.research.g
 1. Create a Replicate [API Token](https://replicate.com/account/api-tokens).
 
 1. Add your Replicate API Token to the Colab Secrets manager to securely store it. Open [Google Colab](https://colab.research.google.com) and click on the 🔑 Secrets tab in the left panel. Click "New Secret" and enter `REPLICATE_API_TOKEN` as the key, and paste your token into the value field. Toggle the button on the left to allow notebook access to the secret.
-
-#### Ollama running in Colab
-
-!!! note "Limitations"
-    Running the Ollama server in Colab will limit the size of Granite models you can use and be _significantly_ slower when calling the Granite models. It is therefore recommended to use [Replicate AI Cloud Platform for Colab](#replicate-ai-cloud-platform-for-colab) instead.
-
-!!! attention "GPU Hardware Accelerator"
-    Once each notebook has been opened in Colab, you can modify the notebook's runtime type to select a GPU hardware accelerator.
-    Using the "Runtime->Change runtime type" menu item, select "T4 GPU" instead of "CPU" and save.
-    This will improve the performance of the Ollama server.
-    There are limitations on using a GPU hardware accelerator especially on the free tier. Check out documentation for more details.
-
-The Jupyter notebooks for [Lab 1: Document Summarization with Granite](../lab-1/README.md), [Lab 2: Retrieval Augmented Generation (RAG) with Langchain](../lab-2/README.md) and [Lab 4: Generating Bash Code with Granite Code](../lab-4/README.md) include cells for the steps that need to be executed to run Ollama in Colab. Run the relevant cells when you are running the notebook.

--- a/notebooks/RAG_with_Langchain.ipynb
+++ b/notebooks/RAG_with_Langchain.ipynb
@@ -83,11 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install \\\n",
-    "  \"git+https://github.com/ibm-granite-community/granite-kitchen.git\" \\\n",
-    "  \"langchain-huggingface\" \\\n",
-    "  \"langchain-milvus\" \\\n",
-    "  \"wget\""
+    "! pip install \"git+https://github.com/ibm-granite-community/granite-kitchen.git\" \"langchain-huggingface\" \"langchain-milvus\" \"wget\""
    ]
   },
   {
@@ -104,69 +100,7 @@
     "\n",
     "This notebook requires IBM Granite models to be served by an AI model runtime so that the models can be invoked or called. This notebook can use a locally accessible [Ollama](https://github.com/ollama/ollama) server to serve the models, or the [Replicate](https://replicate.com) cloud service.\n",
     "\n",
-    "During the pre-work, you may have either started a local Ollama server on your computer, or setup Replicate access and obtained an [API token](https://replicate.com/account/api-tokens). In this case, you can skip the \"Running Ollama in Colab\" section below."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Running Ollama in Colab\n",
-    "\n",
-    "This section is required if you are not going to either run the Ollama server locally on your computer or use the Replicate cloud service. Running the Ollama server in Colab will limit the size of Granite models you can use and be _significantly_ slower when calling the Granite models.\n",
-    "\n",
-    "> **Note:** You can modify the notebook's runtime type to select a GPU hardware accelerator. Using the \"Runtime->Change runtime type\" menu item, select \"T4 GPU\" instead of \"CPU\" and save. This will improve the performance of the Ollama server. There are limitations on using a GPU hardware accelerator especially on the free tier. Check out documentation for more details."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "1. Download and install Ollama in Colab"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!curl https://ollama.ai/install.sh | sh"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "2. Start the Ollama server as a background process in Colab using `nohup` and `&`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.system(\"nohup ollama serve &\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "3. Pull down the Granite models in Colab that you will use in the workshop. Larger models take more memory to run."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ollama pull granite3-dense:2b\n",
-    "!ollama pull granite3-dense:8b"
+    "During the pre-work, you may have either started a local Ollama server on your computer, or setup Replicate access and obtained an [API token](https://replicate.com/account/api-tokens)."
    ]
   },
   {

--- a/notebooks/RAG_with_Langchain.ipynb
+++ b/notebooks/RAG_with_Langchain.ipynb
@@ -342,9 +342,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Automate the RAG pipeline\n",
-    "\n",
-    "Build a RAG chain with the model and the document retriever."
+    "### Automate the RAG pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Build a RAG chain with the model and the document retriever. See the [Granite Prompting Guide](https://www.ibm.com/granite/docs/models/granite/#prompt-anatomy) for information on the prompt template."
    ]
   },
   {

--- a/notebooks/Summarize.ipynb
+++ b/notebooks/Summarize.ipynb
@@ -20,6 +20,25 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Python version\n",
+    "\n",
+    "Ensure you are running Python 3.10 or 3.11."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "assert sys.version_info >= (3, 10) and sys.version_info < (3, 12), \"Use Python 3.10 or 3.11 to run this notebook.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "IwS1CzAbaFzq"
    },
@@ -37,10 +56,7 @@
    },
    "outputs": [],
    "source": [
-    "! pip install git+https://github.com/ibm-granite-community/granite-kitchen \\\n",
-    "    'transformers>=4.45.2' \\\n",
-    "    torch \\\n",
-    "    tiktoken"
+    "! pip install \"git+https://github.com/ibm-granite-community/granite-kitchen\" \"transformers>=4.45.2\" torch tiktoken"
    ]
   },
   {
@@ -57,69 +73,7 @@
     "\n",
     "This notebook requires IBM Granite models to be served by an AI model runtime so that the models can be invoked or called. This notebook can use a locally accessible [Ollama](https://github.com/ollama/ollama) server to serve the models, or the [Replicate](https://replicate.com) cloud service.\n",
     "\n",
-    "During the pre-work, you may have either started a local Ollama server on your computer, or setup Replicate access and obtained an [API token](https://replicate.com/account/api-tokens). In this case, you can skip the \"Running Ollama in Colab\" section below."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Running Ollama in Colab\n",
-    "\n",
-    "This section is required if you are not going to either run the Ollama server locally on your computer or use the Replicate cloud service. Running the Ollama server in Colab will limit the size of Granite models you can use and be _significantly_ slower when calling the Granite models.\n",
-    "\n",
-    "> **Note:** You can modify the notebook's runtime type to select a GPU hardware accelerator. Using the \"Runtime->Change runtime type\" menu item, select \"T4 GPU\" instead of \"CPU\" and save. This will improve the performance of the Ollama server. There are limitations on using a GPU hardware accelerator especially on the free tier. Check out documentation for more details."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "1. Download and install Ollama in Colab"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!curl https://ollama.ai/install.sh | sh"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "2. Start the Ollama server as a background process in Colab using `nohup` and `&`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.system(\"nohup ollama serve &\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "3. Pull down the Granite models in Colab that you will use in the workshop. Larger models take more memory to run."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ollama pull granite3-dense:2b\n",
-    "!ollama pull granite3-dense:8b"
+    "During the pre-work, you may have either started a local Ollama server on your computer, or setup Replicate access and obtained an [API token](https://replicate.com/account/api-tokens)."
    ]
   },
   {

--- a/notebooks/Summarize.ipynb
+++ b/notebooks/Summarize.ipynb
@@ -207,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use this optimial question-answer format according to the Granite Prompting Guide."
+    "Use this optimal question-answer format according to the [Granite Prompting Guide](https://www.ibm.com/granite/docs/models/granite/#prompt-anatomy)."
    ]
   },
   {

--- a/notebooks/Text_to_Shell.ipynb
+++ b/notebooks/Text_to_Shell.ipynb
@@ -25,6 +25,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Python version\n",
+    "\n",
+    "Ensure you are running Python 3.10 or 3.11."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "assert sys.version_info >= (3, 10) and sys.version_info < (3, 12), \"Use Python 3.10 or 3.11 to run this notebook.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Install dependencies\n",
     "\n",
     "Granite Kitchen comes with a bundle of dependencies that are required for notebooks. See the list of packages in its [`setup.py`](https://github.com/ibm-granite-community/granite-kitchen/blob/main/setup.py). "
@@ -36,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen"
+    "! pip install \"git+https://github.com/ibm-granite-community/granite-kitchen\""
    ]
   },
   {
@@ -53,69 +72,7 @@
     "\n",
     "This notebook requires IBM Granite models to be served by an AI model runtime so that the models can be invoked or called. This notebook can use a locally accessible [Ollama](https://github.com/ollama/ollama) server to serve the models, or the [Replicate](https://replicate.com) cloud service.\n",
     "\n",
-    "During the pre-work, you may have either started a local Ollama server on your computer, or setup Replicate access and obtained an [API token](https://replicate.com/account/api-tokens). In this case, you can skip the \"Running Ollama in Colab\" section below."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Running Ollama in Colab\n",
-    "\n",
-    "This section is required if you are not going to either run the Ollama server locally on your computer or use the Replicate cloud service. Running the Ollama server in Colab will limit the size of Granite models you can use and be _significantly_ slower when calling the Granite models.\n",
-    "\n",
-    "> **Note:** You can modify the notebook's runtime type to select a GPU hardware accelerator. Using the \"Runtime->Change runtime type\" menu item, select \"T4 GPU\" instead of \"CPU\" and save. This will improve the performance of the Ollama server. There are limitations on using a GPU hardware accelerator especially on the free tier. Check out documentation for more details."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "1. Download and install Ollama in Colab"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!curl https://ollama.ai/install.sh | sh"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "2. Start the Ollama server as a background process in Colab using `nohup` and `&`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.system(\"nohup ollama serve &\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "3. Pull down the Granite models in Colab that you will use in the workshop. Larger models take more memory to run."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ollama pull granite-code:3b\n",
-    "!ollama pull granite-code:8b"
+    "During the pre-work, you may have either started a local Ollama server on your computer, or setup Replicate access and obtained an [API token](https://replicate.com/account/api-tokens)."
    ]
   },
   {

--- a/notebooks/Time_Series_Getting_Started.ipynb
+++ b/notebooks/Time_Series_Getting_Started.ipynb
@@ -24,10 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install the tsfm library\n",
-    "! pip install \\\n",
-    "  \"tsfm_public[notebooks] @ git+https://github.com/ibm-granite/granite-tsfm.git@v0.2.12\" -U \\\n",
-    "  \"wget\""
+    "! pip install \"tsfm_public[notebooks] @ git+https://github.com/ibm-granite/granite-tsfm.git@v0.2.12\" -U \"wget\""
    ]
   },
   {


### PR DESCRIPTION
We clean up the pip installs for windows which did not like the single quotes or the backslashes.

We also add checks for the proper python versions. Students with Python 3.13 (which is the current release) failed to pip install torch.

We also remove the notebook cells for installing ollama in colab. Even those students who planned to use Replicate, still ran the cells to install ollama in colab which was a poor experience. So we basically remove the ollama-in-colab information from the workshop.