### PR TITLE
Workaround for numpy version problem between colab and granite-tsfm

### DIFF
--- a/notebooks/Time_Series_Getting_Started.ipynb
+++ b/notebooks/Time_Series_Getting_Started.ipynb
@@ -25,7 +25,11 @@
    "outputs": [],
    "source": [
     "# Install the tsfm library\n",
-    "! pip install \"granite-tsfm[notebooks]==v0.2.22\" -U"
+    "! pip install \"granite-tsfm[notebooks]==v0.2.22\"\n",
+    "\n",
+    "import sys\n",
+    "if 'google.colab' in sys.modules:\n",
+    "    ! pip install --force-reinstall --no-warn-conflicts \"numpy<2.1.0,>=2.0.2\""
    ]
   },
   {


### PR DESCRIPTION
See https://github.com/ibm-granite/granite-tsfm/issues/282