### PR TITLE
Install sentence_transformers

### DIFF
--- a/notebooks/Granite_Multimodal_RAG.ipynb
+++ b/notebooks/Granite_Multimodal_RAG.ipynb
@@ -146,7 +146,7 @@
     "    transformers \\\n",
     "    pillow \\\n",
     "    langchain_community \\\n",
-    "    langchain_huggingface \\\n",
+    "    'langchain_huggingface[full]' \\\n",
     "    langchain_milvus \\\n",
     "    docling \\\n",
     "    replicate"

--- a/notebooks/RAG_with_Langchain.ipynb
+++ b/notebooks/RAG_with_Langchain.ipynb
@@ -104,7 +104,7 @@
     "! pip install git+https://github.com/ibm-granite-community/utils \\\n",
     "    transformers \\\n",
     "    langchain_community \\\n",
-    "    langchain_huggingface \\\n",
+    "    'langchain_huggingface[full]' \\\n",
     "    langchain_ollama \\\n",
     "    langchain_milvus \\\n",
     "    replicate \\\n",

--- a/notebooks/Summarize.ipynb
+++ b/notebooks/Summarize.ipynb
@@ -69,7 +69,6 @@
     "! pip install git+https://github.com/ibm-granite-community/utils \\\n",
     "    langchain_community \\\n",
     "    transformers \\\n",
-    "    langchain_huggingface \\\n",
     "    langchain_ollama \\\n",
     "    replicate \\\n",
     "    docling"


### PR DESCRIPTION
With the change in https://github.com/langchain-ai/langchain/pull/31268, we need to install 'langchain_huggingface[full]' to make sure the sentence_transformers dependency is also installed.